### PR TITLE
兼容 monolog 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "phptars/tars-log",
   "description": "tars的远程日志",
   "minimum-stability": "dev",
-  "version":"0.1.5",
+  "version":"0.2.0",
   "authors": [
     {
       "name": "Chen liang",
@@ -14,8 +14,8 @@
     }
   ],
   "require":{
-    "php": ">=5.5",
-    "monolog/monolog": "^1.23",
+    "php": "^7.2",
+    "monolog/monolog": "^2.0",
     "phptars/tars-client": "~0.1"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "phptars/tars-log",
   "description": "tars的远程日志",
   "minimum-stability": "dev",
-  "version":"0.2.0",
+  "version":"0.1.6",
   "authors": [
     {
       "name": "Chen liang",

--- a/src/handler/TarsHandler.php
+++ b/src/handler/TarsHandler.php
@@ -91,7 +91,7 @@ class TarsHandler extends AbstractProcessingHandler
      * @return void
      * @throws \Exception
      */
-    protected function write(array $record)
+    protected function write(array $record):void
     {
         $this->logServant->logger($this->app, $this->server, $record['channel'], $this->dateFormat, [$record['formatted']]);
     }


### PR DESCRIPTION
好多新框架已经最低要求monolog2了，1.23兼容不了，导致使用不了phptars。进行了不兼容旧版更改，所以版本号提了。